### PR TITLE
Account for UIImage scale factor when determining if image is large enough.

### DIFF
--- a/DMActivityInstagram/DMActivityInstagram.m
+++ b/DMActivityInstagram/DMActivityInstagram.m
@@ -117,7 +117,7 @@
 
 -(BOOL)imageIsLargeEnough:(UIImage *)image {
     CGSize imageSize = [image size];
-    return (imageSize.height >= 612 && imageSize.width >= 612);
+    return (imageSize.height * image.scale >= 612 && imageSize.width * image.scale >= 612);
 }
 
 -(BOOL)imageIsSquare:(UIImage *)image {


### PR DESCRIPTION
Hi there, when I was sharing a UIImage created via programmatic screenshot the image was getting rejected as too small. What seemed to be happening though was the UIImage had a scale factor of 2. I think this change accounts for that, but I might be wrong since I didn't know a UIImage could have a scale until an hour ago, hah.
