### PR TITLE
Avoid warning with strict warnings set

### DIFF
--- a/DMActivityInstagram/DMResizerViewController.m
+++ b/DMActivityInstagram/DMResizerViewController.m
@@ -130,7 +130,7 @@
     CGContextRef context = UIGraphicsGetCurrentContext();
     
     [self.imageView.backgroundColor setFill];
-    CGContextFillRect(context, (CGRect){0,0,640,640});
+    CGContextFillRect(context, (CGRect){{0,0},{640,640}});
     
     // Required to apply rotation, move the axis of rotation by a little bit
     CGContextTranslateCTM(context, 320, 320); // drawingRect has been offset to handle this


### PR DESCRIPTION
Fixes warning with "hosey" level warnings set.  No functional change.  I'm using these settings: http://robots.thoughtbot.com/post/40870101931/opinionated-settings-for-app-development-in-xcode
