### PR TITLE
- added support for custom resizer controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Created by http://www.gitignore.io
+
+### OSX ###
+.DS_Store
+
+# Thumbnails
+._*
+
+### Objective-C ###
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+
+Pods/
+
+### Xcode ###
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.xcuserstate

--- a/DMActivityInstagram.xcodeproj/project.pbxproj
+++ b/DMActivityInstagram.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		8BFEBF96160C774900A4A213 /* instagram@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "instagram@2x.png"; sourceTree = "<group>"; };
 		8BFEBF97160C774900A4A213 /* instagram~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "instagram~ipad.png"; sourceTree = "<group>"; };
 		8BFEBF98160C774900A4A213 /* instagram~ipad@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "instagram~ipad@2x.png"; sourceTree = "<group>"; };
+		A7242DBB19A63BEE000F44FF /* DMResizerViewControllerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DMResizerViewControllerDelegate.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +133,7 @@
 				8B03DB0A160C5DD50070B8B0 /* DMAppDelegate.m */,
 				8B03DB12160C5DD50070B8B0 /* DMAIDemoViewController.h */,
 				8B03DB13160C5DD50070B8B0 /* DMAIDemoViewController.m */,
+				A7242DBB19A63BEE000F44FF /* DMResizerViewControllerDelegate.h */,
 				8B03DB22160C62700070B8B0 /* DMActivityInstagram.h */,
 				8B03DB23160C62700070B8B0 /* DMActivityInstagram.m */,
 				8B03DB29160C6CEC0070B8B0 /* DMResizerViewController.h */,

--- a/DMActivityInstagram.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/DMActivityInstagram.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:DMActivityInstagram.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/DMActivityInstagram/DMActivityInstagram.h
+++ b/DMActivityInstagram/DMActivityInstagram.h
@@ -7,7 +7,22 @@
 //
 
 #import <UIKit/UIKit.h>
-#import "DMResizerViewController.h"
+
+@class DMResizerViewController;
+@protocol DMResizerViewControllerDelegate;
+
+@protocol DMResizerDelegate <NSObject>
+
+-(void)resizer:(UIViewController<DMResizerViewControllerDelegate> *)resizer finishedResizingWithResult:(UIImage *)image;
+-(NSArray *)backgroundColors;
+
+@end
+
+@protocol DMActivityInstagramDelegate <NSObject>
+
+- (UIViewController<DMResizerViewControllerDelegate> *)viewControllerForResizing;
+
+@end
 
 @interface DMActivityInstagram : UIActivity <DMResizerDelegate, UIDocumentInteractionControllerDelegate>
 
@@ -19,8 +34,8 @@
 @property (nonatomic, strong) UIBarButtonItem *presentFromButton;
 // overwritten if shareImage is non-square, because the document-interaction-controller is presented in the resize view.
 
-@property (nonatomic, strong) DMResizerViewController *resizeController;
-
 @property (nonatomic, strong) UIDocumentInteractionController *documentController;
+
+@property (nonatomic, weak) id<DMActivityInstagramDelegate> delegate;
 
 @end

--- a/DMActivityInstagram/DMActivityInstagram.m
+++ b/DMActivityInstagram/DMActivityInstagram.m
@@ -7,6 +7,13 @@
 //
 
 #import "DMActivityInstagram.h"
+#import "DMResizerViewController.h"
+
+@interface DMActivityInstagram()
+
+@property (nonatomic, strong) UIViewController<DMResizerViewControllerDelegate> *resizeController;
+
+@end
 
 @implementation DMActivityInstagram
 
@@ -55,7 +62,17 @@
 - (UIViewController *)activityViewController {
     // resize controller if resize is required.
     if (!self.resizeController) {
-        self.resizeController = [[DMResizerViewController alloc] initWithImage:self.shareImage andDelegate:self];
+        
+        if ([self.delegate viewControllerForResizing]) {
+            self.resizeController = [self.delegate viewControllerForResizing];
+        } else {
+            self.resizeController = [DMResizerViewController new];
+        }
+        
+        self.resizeController.resizerDelegate = self;
+        self.resizeController.inputImage = [UIImage imageWithCGImage:self.shareImage.CGImage
+                                                               scale:self.shareImage.scale
+                                                         orientation:UIImageOrientationUp];
         
         if ([self imageIsSquare:self.shareImage]) {
             self.resizeController.skipCropping = YES;
@@ -64,7 +81,8 @@
     return self.resizeController;
 }
 
--(void)resizer:(DMResizerViewController *)resizer finishedResizingWithResult:(UIImage *)image {
+#pragma mark - DMResizerControllerDelegate
+-(void)resizer:(UIViewController<DMResizerViewControllerDelegate> *)resizer finishedResizingWithResult:(UIImage *)image {
     if (image == nil) {
         if (self.documentController) {
             [self.documentController dismissMenuAnimated:YES];
@@ -72,7 +90,7 @@
         [self activityDidFinish:NO];
         return;
     } else {
-        self.presentFromButton = resizer.doneButton;
+        self.presentFromButton = resizer.doneButtonForDocumentController;
         self.shareImage = image;
         // performActivity
         [self performActivity];

--- a/DMActivityInstagram/DMResizerViewController.h
+++ b/DMActivityInstagram/DMResizerViewController.h
@@ -8,21 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
+#import "DMActivityInstagram.h"
+#import "DMResizerViewControllerDelegate.h"
 #import "DMColorPickerView.h"
 
-@class DMResizerViewController;
-
-@protocol DMResizerDelegate <NSObject>
-
--(void)resizer:(DMResizerViewController *)resizer finishedResizingWithResult:(UIImage *)image;
--(NSArray *)backgroundColors;
-
-@end
-
-
-@interface DMResizerViewController : UIViewController <UIScrollViewDelegate, DMColorPickerDelegate>
-
-@property (readwrite) BOOL skipCropping;
+@interface DMResizerViewController : UIViewController <UIScrollViewDelegate, DMColorPickerDelegate, DMResizerViewControllerDelegate>
 
 @property (nonatomic, strong) IBOutlet UIImageView *imageView;
 @property (nonatomic, strong) IBOutlet UIScrollView *scrollView;
@@ -31,20 +21,12 @@
 @property (nonatomic, strong) IBOutlet UIView *bottomView;
 @property (nonatomic, strong) IBOutlet UIView *topView;
 
-@property (nonatomic, strong) IBOutlet UIBarButtonItem *doneButton;
-
 @property (nonatomic, strong) IBOutlet DMColorPickerView *colorPicker;
-
-@property (nonatomic, strong) UIImage *inputImage;
-
-@property (nonatomic, strong) id <DMResizerDelegate> delegate;
 
 -(IBAction)doneButtonAction;
 -(IBAction)rotateButtonAction;
 -(IBAction)cancelButtonAction;
 
 -(IBAction)changeColor:(id)sender;
-
--(id)initWithImage:(UIImage *)imageObject andDelegate:(id<DMResizerDelegate>)delegate;
 
 @end

--- a/DMActivityInstagram/DMResizerViewController.m
+++ b/DMActivityInstagram/DMResizerViewController.m
@@ -8,40 +8,29 @@
 
 #import "DMResizerViewController.h"
 
-
 @interface DMResizerViewController () {
     CGFloat rotation;
+    
+    BOOL skipCropping;
+    UIImage *inputImage;
+    __weak id<DMResizerDelegate> resizerDelegate;
 }
+
+@property (nonatomic, strong) IBOutlet UIBarButtonItem *doneButton;
+
 @end
 
 
 @implementation DMResizerViewController
 
--(id)initWithImage:(UIImage *)imageObject andDelegate:(id<DMResizerDelegate>)delegate {
-    if (!(self = [super initWithNibName:@"DMResizerViewController" bundle:nil])) return nil;
-    
-    self.delegate = delegate;
-    
-    UIImage *exportImage = [UIImage imageWithCGImage:imageObject.CGImage scale:imageObject.scale orientation:UIImageOrientationUp];
-    
-    self.inputImage = exportImage;
-    
-    
-    return self;
-}
+@synthesize skipCropping;
+@synthesize inputImage;
+@synthesize resizerDelegate;
 
-- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+#pragma mark - DMResizerViewControllerDelegate
+- (UIBarButtonItem*)doneButtonForDocumentController
 {
-    NSAssert(FALSE, @"Don't call initWithNibName, use initWithImage instead");
-    return nil;
-}
-
-- (void)didReceiveMemoryWarning
-{
-    // Releases the view if it doesn't have a superview.
-    [super didReceiveMemoryWarning];
-    
-    // Release any cached data, images, etc that aren't in use.
+    return self.doneButton;
 }
 
 #pragma mark - View lifecycle
@@ -51,7 +40,7 @@
     [super viewDidLoad];
    
     self.colorPicker.delegate = self; 
-    self.colorPicker.colors = [self.delegate backgroundColors];
+    self.colorPicker.colors = [self.resizerDelegate backgroundColors];
     
     
     self.navigationController.navigationBarHidden = YES;
@@ -155,8 +144,8 @@
 
     // newImage is the result.
 
-    NSAssert([self.delegate conformsToProtocol:@protocol(DMResizerDelegate)], @"Bad delegate %@", self.delegate);
-    [self.delegate resizer:self finishedResizingWithResult:newImage];
+    NSAssert([self.resizerDelegate conformsToProtocol:@protocol(DMResizerDelegate)], @"Bad delegate %@", self.resizerDelegate);
+    [self.resizerDelegate resizer:self finishedResizingWithResult:newImage];
 }
 
 - (void)scrollViewDidZoom:(UIScrollView *)aScrollView {
@@ -170,8 +159,8 @@
 }
 
 -(IBAction)cancelButtonAction {
-    NSAssert([self.delegate conformsToProtocol:@protocol(DMResizerDelegate)], @"Bad delegate %@", self.delegate);
-    [self.delegate resizer:self finishedResizingWithResult:nil]; // nil image == cancel button.
+    NSAssert([self.resizerDelegate conformsToProtocol:@protocol(DMResizerDelegate)], @"Bad delegate %@", self.resizerDelegate);
+    [self.resizerDelegate resizer:self finishedResizingWithResult:nil]; // nil image == cancel button.
 }
 
 -(void)rotateButtonAction {

--- a/DMActivityInstagram/DMResizerViewControllerDelegate.h
+++ b/DMActivityInstagram/DMResizerViewControllerDelegate.h
@@ -1,0 +1,19 @@
+//
+//  DMResizerViewControllerProtocol.h
+//  DMActivityInstagram
+//
+//  Created by Jeremias Nuñez on 8/21/14.
+//  Copyright (c) 2014 Cory Alder. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol DMResizerViewControllerDelegate <NSObject>
+
+- (UIBarButtonItem*)doneButtonForDocumentController;
+
+@property (nonatomic, assign) BOOL skipCropping;
+@property (nonatomic, weak) id<DMResizerDelegate> resizerDelegate;
+@property (nonatomic, strong) UIImage *inputImage;
+
+@end


### PR DESCRIPTION
This gives anyone the chance to create their own custom resizing controllers easily, you just have to implement the `DMResizerViewControllerProtocol` in your view controller and make sure to call the `resizerDelegate` when you've fixed the image to the correct size.
