### PR TITLE
add instagram to the ios9 canOpenURL whitelist

### DIFF
--- a/DMActivityInstagram/DMActivityInstagram-Info.plist
+++ b/DMActivityInstagram/DMActivityInstagram-Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>instagram</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
ios9 will not show instagram uri's as being open-able unless they are whitelisted.  

http://stackoverflow.com/questions/30987986/ios-9-not-opening-instagram-app-with-url-scheme
