### PR TITLE
Setting shared image overrides activity items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+DMActivityInstagram.xcodeproj/project.xcworkspace/xcuserdata
+DMActivityInstagram.xcodeproj/xcuserdata

--- a/DMActivityInstagram/DMActivityInstagram.m
+++ b/DMActivityInstagram/DMActivityInstagram.m
@@ -28,6 +28,10 @@
     NSURL *instagramURL = [NSURL URLWithString:@"instagram://app"];
     if (![[UIApplication sharedApplication] canOpenURL:instagramURL]) return NO; // no instagram.
     
+    if (self.shareImage) {
+        if ([self imageIsLargeEnough:self.shareImage]) return YES; // has image, of sufficient size.
+    }
+    
     for (UIActivityItemProvider *item in activityItems) {
         if ([item isKindOfClass:[UIImage class]]) {
             if ([self imageIsLargeEnough:(UIImage *)item]) return YES; // has image, of sufficient size.
@@ -39,7 +43,7 @@
 
 - (void)prepareWithActivityItems:(NSArray *)activityItems {
     for (id item in activityItems) {
-        if ([item isKindOfClass:[UIImage class]]) self.shareImage = item;
+        if ([item isKindOfClass:[UIImage class]]) self.shareImage = self.shareImage ?: item;
         else if ([item isKindOfClass:[NSString class]]) {
             self.shareString = [(self.shareString ? self.shareString : @"") stringByAppendingFormat:@"%@%@",(self.shareString ? @" " : @""),item]; // concat, with space if already exists.
         }


### PR DESCRIPTION
Setting shareImage should override activity item image,
For e.g. a high resolution image can be used for Instagram sharing, 
while activity items contains a lower resolution image for sharing through other channels.

Leaving shareImage as nil will behave the same.
